### PR TITLE
Properly working support for producer compression

### DIFF
--- a/src/main/kotlin/org/wonderbeat/ConnectionPool.kt
+++ b/src/main/kotlin/org/wonderbeat/ConnectionPool.kt
@@ -35,7 +35,7 @@ class ConnectionsPool<T>(hostList: Set<HostPort>,
         /**
          * Wrapper around dirty Kafka API
          */
-        fun syncProducer(hostPort: HostPort, socketTimeoutMills: Int, requestTimeout: Int, compressionCodec: CompressionCodec,
+        fun syncProducer(hostPort: HostPort, socketTimeoutMills: Int, requestTimeout: Int,
                          sendBufferBytes: Int = 3*1024*1024, clientId: String = "aquana-producer"): SyncProducer {
             val p = Properties()
             p.put("host", hostPort.host)
@@ -44,7 +44,6 @@ class ConnectionsPool<T>(hostList: Set<HostPort>,
             p.put("request.timeout.ms", requestTimeout.toString())
             p.put("send.buffer.bytes", sendBufferBytes.toString() )
             p.put("client.id",  clientId)
-            p.put("compression.codec", compressionCodec.name())
             return SyncProducer(SyncProducerConfig(p))
         }
 

--- a/src/main/kotlin/org/wonderbeat/Mirror.kt
+++ b/src/main/kotlin/org/wonderbeat/Mirror.kt
@@ -55,7 +55,7 @@ fun run(cfg: MirrorConfig): MirrorStatistics {
             ConnectionsPool.genericPool(cfg.connectionsMax))
 
     val producersPool = ConnectionsPool(producerPartitionsLeaders.values.toSet(),
-            { hostPort -> ConnectionsPool.syncProducer(hostPort, cfg.socketTimeoutMills, cfg.requestTimeout, cfg.compressionCodec)},
+            { hostPort -> ConnectionsPool.syncProducer(hostPort, cfg.socketTimeoutMills, cfg.requestTimeout)},
             { it.close() },
             ConnectionsPool.genericPool(cfg.connectionsMax))
     val (consumerPartitionsMeta, producerPartitionsMeta) = invokeConcurrently(
@@ -69,7 +69,7 @@ fun run(cfg: MirrorConfig): MirrorStatistics {
                 }
             }).collectToList()
 
-    val producers = initProducers(producersPool, producerPartitionsMeta)
+    val producers = initProducers(producersPool, producerPartitionsMeta, cfg.compressionCodec)
     val consumers = initConsumers(consumersPool, consumerPartitionsMeta, cfg.fetchSize, cfg.startFrom)
     val offsetWeStartWith = consumers.mapValues { it.value.offset() }
 

--- a/src/main/kotlin/org/wonderbeat/Producers.kt
+++ b/src/main/kotlin/org/wonderbeat/Producers.kt
@@ -7,9 +7,14 @@ import kafka.api.ProducerRequest
 import kafka.api.ProducerResponse
 import kafka.common.TopicAndPartition
 import kafka.message.ByteBufferMessageSet
+import kafka.message.CompressionCodec
+import kafka.message.Message
+import kafka.message.`NoCompressionCodec$`
 import kafka.producer.SyncProducer
 import org.slf4j.LoggerFactory
 import scala.collection.JavaConversions.asScalaMap
+import scala.collection.Seq
+import scala.collection.mutable.`WrappedArray$`
 import java.util.concurrent.atomic.AtomicInteger
 
 private val logger = LoggerFactory.getLogger("org.wonderbeat.producers")
@@ -22,9 +27,33 @@ class RetryingProducer(val producer: Producer,
                                .withRetryListener(logAttemptFailure)
                                .withStopStrategy(StopStrategies.stopAfterAttempt(5))
                                .build()): Producer by producer {
-    override fun write(messages: ByteBufferMessageSet): ProducerResponse =
-            retryer.call { producer.write(messages) }
+    override fun write(serialized: ByteBufferMessageSet): ProducerResponse =
+            retryer.call { producer.write(serialized) }
 }
+
+class CompressingProducer(val producer: Producer, val compressionCodec: CompressionCodec): Producer by producer {
+    override fun write(serialized: ByteBufferMessageSet): ProducerResponse {
+        val shouldCompress = ! compressionCodec.equals(`NoCompressionCodec$`.`MODULE$`)
+
+        val messages = if (shouldCompress) {
+            // the most straightforward way is to just repack messages
+            // could be optimized, but we will need to replicate and support code similar to original kafka compression
+            ByteBufferMessageSet(compressionCodec, unserialize(serialized))
+        } else {
+            serialized
+        }
+
+        return producer.write(messages)
+    }
+
+    private fun unserialize(xs: ByteBufferMessageSet): Seq<Message> {
+        val it = scala.collection.JavaConverters.asJavaIteratorConverter(xs.iterator()).asJava()
+        val messages = it.asSequence().toList().map { msg -> msg.message() }
+        val array = messages.toTypedArray()
+        return `WrappedArray$`.`MODULE$`.make<Message>(array).toSeq()
+    }
+}
+
 
 class PoolAwareProducer(val topic: String,
                         val partition: Int,
@@ -35,8 +64,8 @@ class PoolAwareProducer(val topic: String,
 
     private val correlationId = AtomicInteger(0)
 
-    override fun write(messages: ByteBufferMessageSet): ProducerResponse {
-        val request = createRequest(messages)
+    override fun write(serialized: ByteBufferMessageSet): ProducerResponse {
+        val request = createRequest(serialized)
         val connection = producerPool.borrowConnection(partition)
         try {
             return connection.send(request)
@@ -56,5 +85,5 @@ class PoolAwareProducer(val topic: String,
 }
 
 interface Producer {
-    fun write(messages: ByteBufferMessageSet): ProducerResponse
+    fun write(serialized: ByteBufferMessageSet): ProducerResponse
 }


### PR DESCRIPTION
Previous take wasn't actually working because mirror uses low-level producer API